### PR TITLE
hook up basic NotebookKernel

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	],
 	"activationEvents": [
 		"onCommand:extension.helloWorld",
-		"onNotebook:art-book-provider"
+		"onNotebook:art-book"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -27,8 +27,8 @@
 		],
 		"notebookProvider": [
 			{
-				"viewType": "art-book-provider",
-				"displayName": "Art-Book Provider",
+				"viewType": "art-book",
+				"displayName": "Art-Book",
 				"selector": [
 					{
 						"filenamePattern": "*.art-book"

--- a/src/NotebookKernel/artBookKernel.ts
+++ b/src/NotebookKernel/artBookKernel.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-empty-function */ // TODO: Just for skeleton implementation
+import * as vscode from 'vscode';
+
+export class ArtBookKernel implements vscode.NotebookKernel {
+    // A few general properties for our kernel
+    public readonly id = 'art-book-kernel';
+    public readonly label = 'Art-Book Kernel';
+    public readonly supportedLanguages = ['python', 'markdown'];
+
+    // Public functions for our kernel
+    executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell) {
+        console.log(cell.document.getText());
+    }
+    cancelCellExecution(document: vscode.NotebookDocument, cell: vscode.NotebookCell) {}
+    executeAllCells(document: vscode.NotebookDocument) {}
+    cancelAllCellsExecution(document: vscode.NotebookDocument) {}
+}

--- a/src/NotebookKernel/artBookKernelProvider.ts
+++ b/src/NotebookKernel/artBookKernelProvider.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode';
+import { ArtBookKernel } from './artBookKernel';
+
+export class ArtBookKernelProvider implements vscode.NotebookKernelProvider {
+    // Simple as our ContentProvider => NotebookKernel is a 1:1 link
+    provideKernels() {
+		return [new ArtBookKernel()];
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ArtBookProvider } from "./ContentProvider/artBookProvider";
+import { ArtBookKernelProvider } from './NotebookKernel/artBookKernelProvider';
 
 export function activate(context: vscode.ExtensionContext) {
 	const disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
@@ -11,9 +12,13 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.notebook.registerNotebookContentProvider(
-			'art-book-provider',
+			'art-book',
 			new ArtBookProvider()
 		)
+	);
+
+	context.subscriptions.push(
+		vscode.notebook.registerNotebookKernelProvider({ viewType: 'art-book'}, new ArtBookKernelProvider())
 	);
 
 	context.subscriptions.push(disposable);


### PR DESCRIPTION
Hook up the basic outline of a NotebookKernel. Just enough to hit a BP in executeCell when running from the notebook viewType.